### PR TITLE
Log name when validate name has been called

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -63,6 +63,7 @@ pub fn identity_disconnected(ctx: &ReducerContext) {
 
 #[spacetimedb::reducer]
 pub fn set_name(ctx: &ReducerContext, name: String) -> Result<(), String> {
+    log::info!("Setting name to: {}", name);
     let name = validate_name(name)?;
     if let Some(user) = ctx.db.user().identity().find(ctx.sender) {
         ctx.db.user().identity().update(User {
@@ -90,6 +91,7 @@ pub fn send_message(ctx: &ReducerContext, text: String) -> Result<(), String> {
 
 /// Takes a name and checks if it's acceptable as a user's name.
 fn validate_name(name: String) -> Result<String, String> {
+    log::info!("Validating name: {}", name);
     if name.is_empty() {
         Err("Names must not be empty".to_string())
     } else {


### PR DESCRIPTION
Add log statements to `validate_name` and `set_name` functions.

* Add a log statement in the `validate_name` function to log the name being validated.
* Add a log statement in the `set_name` reducer to log the name being set.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zeroLR/spacetime-rs-chat-demo/pull/1?shareId=03688373-f905-4d57-93bc-7af8d8048390).